### PR TITLE
Conform to `1.23` format for go version in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module zksecurity/ctf/gkr
 
-go 1.21.7
+go 1.21
 
 require (
 	github.com/consensys/gnark v0.9.2-0.20240124123439-9627e98d814f

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.30.0 h1:SymVODrcRsaRaSInD9yQtKbtWqwsfoPcRff/oRXLj4c=
 github.com/rs/zerolog v1.30.0/go.mod h1:/tk+P47gFdPXq4QYjvCmT5/Gsug2nagsFWBWhAiSi1w=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
Currently:
```
go get -d ./...
go: errors parsing go.mod:
/Users/arnaud/git/zkBank/go.mod:3: invalid go version '1.21.7': must match format 1.23
```

After this change things work fine:
```
go get -d ./...
go: downloading github.com/consensys/gnark v0.9.2-0.20240124123439-9627e98d814f
go: downloading github.com/consensys/gnark-crypto v0.12.2-0.20231221171913-5d5eded6bb15
go: downloading github.com/fxamacker/cbor/v2 v2.5.0
go: downloading github.com/rs/zerolog v1.30.0
go: downloading github.com/blang/semver/v4 v4.0.0
go: downloading github.com/bits-and-blooms/bitset v1.8.0
go: downloading golang.org/x/sys v0.15.0
go: downloading github.com/ingonyama-zk/iciclegnark v0.1.0
go: downloading golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
go: downloading github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b
go: downloading github.com/x448/float16 v0.8.4
go: downloading github.com/mattn/go-isatty v0.0.19
go: downloading github.com/ingonyama-zk/icicle v0.0.0-20230928131117-97f0079e5c71
```

EDIT: `go.sum` was dirty after dependency install, committed the diff in another commit. Feel free to discard or keep it :)